### PR TITLE
Adapt code to new h5

### DIFF
--- a/antea/mcsim/sensor_functions.py
+++ b/antea/mcsim/sensor_functions.py
@@ -9,26 +9,23 @@ def apply_charge_fluctuation(sns_df: pd.DataFrame, DataSiPM_idx: pd.DataFrame):
     according to a value read from the database.
     """
 
-    sum_sns = sns_df.groupby(['event_id','sensor_id'])[['charge']].sum()
-    sum_sns = sum_sns.reset_index()
-    charges = sum_sns.charge.values
+    charges = sns_df.charge.values
     sipmrd  = charges[:, np.newaxis] # IC function expects a waveform
 
     pe_resolution = DataSiPM_idx.Sigma / DataSiPM_idx.adc_to_pes
-    touched_sipms = sum_sns.sensor_id.values
+    touched_sipms = sns_df.sensor_id.values
     pe_res        = pe_resolution[touched_sipms]
 
     sipm_fluct = np.array(tuple(map(charge_fluctuation, sipmrd, pe_res)))
 
     events      = sns_df.event_id.unique()
-    sns_per_evt = sum_sns.event_id.value_counts()
+    sns_per_evt = sns_df.event_id.value_counts()
     instances   = sns_per_evt[events]
 
     evts         = np.repeat(events, instances)
-    t_bins       = np.repeat(0, len(sipmrd))
     fluct_charge = sipm_fluct.flatten()
     fluct_sns    = pd.DataFrame({'event_id': evts, 'sensor_id': touched_sipms,
-                                 'time_bin': t_bins, 'charge': fluct_charge})
+                                 'charge': fluct_charge})
 
     return fluct_sns
 

--- a/antea/mcsim/sensor_functions_test.py
+++ b/antea/mcsim/sensor_functions_test.py
@@ -18,9 +18,12 @@ def test_number_of_sensors_is_the_same(ANTEADATADIR):
     DataSiPM     = db.DataSiPMsim_only('petalo', 0) # full body PET
     DataSiPM_idx = DataSiPM.set_index('SensorID')
 
-    PATH_IN       = os.path.join(ANTEADATADIR, 'full_body_1ev.h5')
+    PATH_IN       = os.path.join(ANTEADATADIR, 'full_body_coinc.h5')
     sns_response  = load_mcsns_response(PATH_IN)
     events        = sns_response.event_id.unique()
+
+    evt = events[0]
+    sns_response = sns_response[sns_response.event_id == evt]
 
     fluct_sns_response = apply_charge_fluctuation(sns_response, DataSiPM_idx)
 

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -43,7 +43,8 @@ def find_SiPMs_over_threshold(df: pd.DataFrame,
                               threshold: float) -> pd.DataFrame:
     """
     Integrate the charge in time of each SiPM and select only those with
-    total charge larger than threshold.
+    total charge larger than threshold. This function is kept to be used
+    with old test files.
     """
     tot_charges_df = df.groupby(['event_id','sensor_id'])[['charge']].sum()
     return tot_charges_df[tot_charges_df.charge > threshold].reset_index()

--- a/antea/scripts/build_r_map.py
+++ b/antea/scripts/build_r_map.py
@@ -44,7 +44,7 @@ def build_r_map(input_file: str, output_file: str, threshold: float):
         exit()
     print(f'Analyzing file {input_file}')
 
-    sel_df = rf.find_SiPMs_over_threshold(sns_response, threshold)
+    sel_df = sns_response[sns_response.charge > threshold]
 
     particles = pd.read_hdf(input_file, 'MC/particles')
     hits      = pd.read_hdf(input_file, 'MC/hits')

--- a/antea/scripts/characterize_coincidences.py
+++ b/antea/scripts/characterize_coincidences.py
@@ -115,7 +115,7 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
     for evt in events:
 
         evt_sns = fluct_sns_response[fluct_sns_response.event_id == evt]
-        evt_sns = rf.find_SiPMs_over_threshold(evt_sns, threshold=thr_e)
+        evt_sns = evt_sns[evt_sns.charge > thr_e]
         if len(evt_sns) == 0:
             continue
 

--- a/antea/scripts/process_mc_petit.py
+++ b/antea/scripts/process_mc_petit.py
@@ -43,4 +43,4 @@ if __name__ == "__main__":
 
     input_file  = str(sys.argv[1])
     output_file = str(sys.argv[2])
-    process_data_petit(input_file, output_file)
+    process_mc_petit(input_file, output_file)

--- a/antea/testdata/full_body_coinc.h5
+++ b/antea/testdata/full_body_coinc.h5
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d9b5d0ac6eebd99530ce056bed3ac8edc2fc2b6d3213173a96de6e033ceb9f09
-size 1403287
+oid sha256:0cd6b3cb84e4c1bb8d5985bb6b83f7d35a908f5df8ea4349ac2aa7f2e64b2852
+size 1235296


### PR DESCRIPTION
This PR fixes a function that still used the old `h5` format with `time_bin` and `charge` in the `sns_response` table and adapts the code to the new format, adding a new test file.