### PR TITLE
Fix GH environment according to IC's latest version

### DIFF
--- a/.github/workflows/test_suite.yml
+++ b/.github/workflows/test_suite.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7]
-        platform: [ubuntu-18.04]
+        python-version: [3.8]
+        platform: [ubuntu-20.04]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
The latest change to the IC environment has broken the action used in this repository. ANTEA has to be updated in the same way.