### PR TITLE
Update Data base with the new sensors_id

### DIFF
--- a/antea/conftest.py
+++ b/antea/conftest.py
@@ -28,7 +28,7 @@ def output_tmpdir(tmpdir_factory):
 
 @pytest.fixture(scope='session',
                 params=[db_data('petalo' ,    3500, 'P7R195Z140mm'),
-                        db_data('petalo' ,     80, 'PB')],
+                        db_data('petalo' ,     128, 'PB')],
                 ids=["petit", "petbox"])
 def db(request):
     return request.param

--- a/antea/database/localdb.PETALODB.sqlite3
+++ b/antea/database/localdb.PETALODB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6577822edc7330241403f12ea2a562f2283df1cd0eb442923a195e8e7c5f59dc
-size 28401664
+oid sha256:6c7e0dda67d045ad5772a42257f10de3d98681c17fe8ac4521bede3e0340c77e
+size 28413952


### PR DESCRIPTION
This PR updates de local copy of the database. In he mysql server the table ChannelPosition was already updated with the current setup (2 dices with 64 sensors), but it was not included in ANTEA.

This PR includes the channel positions for all 128 channels.