### PR TITLE
Add protection to sensor ID variables

### DIFF
--- a/antea/scripts/characterize_coincidences.py
+++ b/antea/scripts/characterize_coincidences.py
@@ -140,6 +140,9 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
             c0 += 1
             continue
 
+        sns1 = sns1.astype('int64')
+        sns2 = sns2.astype('int64')
+
         q1   = np.array(q1)
         q2   = np.array(q2)
         pos1 = np.array(pos1)


### PR DESCRIPTION
In some cases, taking the negative values of the sensor IDs led to incorrect numbers, because they are interpreted as `unsigned int`. This protection should avoid that.