### PR TITLE
Force all element of an array to be of the same type

### DIFF
--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -204,7 +204,9 @@ def find_hit_distances_from_true_pos(hits: pd.DataFrame,
     scalar_products = positions.dot(true_pos)
 
     mask      = scalar_products >= 0
-    distances = np.linalg.norm(np.subtract(positions[mask], true_pos), axis=1)
+    diff      = np.subtract(positions[mask], true_pos)
+    diff      = np.array(diff, dtype=np.float32)
+    distances = np.linalg.norm(diff, axis=1)
 
     return distances
 


### PR DESCRIPTION
Sometimes it happened that the result of the subtraction was of a different type than the original arrays, and this caused an error in the norm function. This PR solves the issue, although it's not clear to me why this error appeared in the first place. It may be related with some specific version of numpy and/or the machine architecture. 
I haven't been able to provide a test, because simply copying the values of the event that fails in a specific machine doesn't make the test fail.