### PR TITLE
Update channel mapping in DB

### DIFF
--- a/antea/database/localdb.PETALODB.sqlite3
+++ b/antea/database/localdb.PETALODB.sqlite3
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6c7e0dda67d045ad5772a42257f10de3d98681c17fe8ac4521bede3e0340c77e
-size 28413952
+oid sha256:ecf5553810d06bac87b24d0a83bd3c5fc50c0b98cd26b21f4bc29865ba7d1585
+size 28422144


### PR DESCRIPTION
After some issues with the connector, TOFPET 0 is now TOFPET 5. This PR updates the channel mapping with the current setup.

The new mapping will keep the sensor ids 11, 12,... 88 for those sensors connected to TOFPET 5.