### PR TITLE
Update package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 # Extra packages apart from those in IC
-sklearn
+scikit-learn


### PR DESCRIPTION
Apparently the name of the scikit learn package needs to be updated, starting from ~a month ago (https://pypi.org/project/sklearn/).
This PR changes the name in the `requirements.txt` file.