### PR TITLE
Adapt to new table

### DIFF
--- a/antea/io/mc_io.py
+++ b/antea/io/mc_io.py
@@ -30,7 +30,6 @@ class mc_sns_response_writer:
         sns_resp_dict = sns_response[evt_number]
         sns_resp = pd.DataFrame({'event_id':  [evt_number for i in range(len(sns_resp_dict))],
                                   'sensor_id': list(sns_resp_dict.keys()),
-                                  'time_bin':  [0 for i in range(len(sns_resp_dict))],
                                   'charge':    list(sns_resp_dict.values())})
         self.store.append('MC/'+self.sns_df_name, sns_resp, format='t', data_columns=True)
 

--- a/antea/reco/reco_functions.py
+++ b/antea/reco/reco_functions.py
@@ -346,8 +346,8 @@ def find_coincidence_timestamps(tof_response: pd.DataFrame,
     Finds the first time and the IDs of the sensors used to calculate it
     for each one of two sets of sensors, given a sensor response dataframe.
     """
-    min1, time1 = find_first_time_of_sensors(tof_response, -sns1, n_pe)
-    min2, time2 = find_first_time_of_sensors(tof_response, -sns2, n_pe)
+    min1, time1 = find_first_time_of_sensors(tof_response, sns1, n_pe)
+    min2, time2 = find_first_time_of_sensors(tof_response, sns2, n_pe)
 
     return min1, min2, time1, time2
 

--- a/antea/scripts/characterize_coincidences.py
+++ b/antea/scripts/characterize_coincidences.py
@@ -10,7 +10,6 @@ import antea.reco.mctrue_functions  as mcf
 import antea.elec.shaping_functions as shf
 import antea.mcsim.sensor_functions as snsf
 
-from antea.io.mc_io import read_sensor_bin_width_from_conf
 from antea.io.mc_io import load_mcparticles, load_mchits
 from antea.io.mc_io import load_mcsns_response, load_mcTOFsns_response
 
@@ -102,8 +101,6 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
 
     fluct_sns_response = snsf.apply_charge_fluctuation(sns_response, DataSiPM_idx)
 
-    tof_bin_size = read_sensor_bin_width_from_conf(input_file, tof=True)
-
     particles    = load_mcparticles      (input_file)
     hits         = load_mchits           (input_file)
     tof_response = load_mcTOFsns_response(input_file)
@@ -119,12 +116,10 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
         if len(evt_sns) == 0:
             continue
 
-        ids_over_thr = evt_sns.sensor_id.astype('int64').values
-
         evt_parts = particles   [particles   .event_id == evt]
         evt_hits  = hits        [hits        .event_id == evt]
         evt_tof   = tof_response[tof_response.event_id == evt]
-        evt_tof   = evt_tof     [evt_tof     .sensor_id.isin(-ids_over_thr)]
+        evt_tof   = evt_tof     [evt_tof     .sensor_id.isin(evt_sns.sensor_id)]
         if len(evt_tof) == 0:
             continue
 
@@ -140,9 +135,6 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
             c0 += 1
             continue
 
-        sns1 = sns1.astype('int64')
-        sns2 = sns2.astype('int64')
-
         q1   = np.array(q1)
         q2   = np.array(q2)
         pos1 = np.array(pos1)
@@ -156,11 +148,13 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
             continue
 
         ## Use absolute times in units of ps
-        times = evt_tof.time_bin.values * tof_bin_size / units.ps
+        times = evt_tof.time / units.ps
         ## add SiPM jitter, if different from zero
         if sigma_sipm > 0:
             times = np.round(np.random.normal(times, sigma_sipm))
-        evt_tof.insert(len(evt_tof.columns), 'time', times.astype(int)) # here we have bins of 1 ps
+        evt_tof = evt_tof.drop('time', axis=1) # drop original time
+        evt_tof.insert(len(evt_tof.columns), 'time', times.astype(int)) # round to 1 ps 
+        evt_tof.insert(len(evt_tof.columns), 'charge', np.ones(len(times)).astype(int)) # add 1 unit of charge per time
 
         ## produce a TOF dataframe with convolved time response
         tof_sns = evt_tof.sensor_id.unique()

--- a/antea/scripts/characterize_coincidences.py
+++ b/antea/scripts/characterize_coincidences.py
@@ -153,7 +153,7 @@ def characterize_coincidences(input_file: str, output_file: str, rmap: str):
         if sigma_sipm > 0:
             times = np.round(np.random.normal(times, sigma_sipm))
         evt_tof = evt_tof.drop('time', axis=1) # drop original time
-        evt_tof.insert(len(evt_tof.columns), 'time', times.astype(int)) # round to 1 ps 
+        evt_tof.insert(len(evt_tof.columns), 'time', np.round(times)) # round to 1 ps 
         evt_tof.insert(len(evt_tof.columns), 'charge', np.ones(len(times)).astype(int)) # add 1 unit of charge per time
 
         ## produce a TOF dataframe with convolved time response

--- a/antea/scripts/process_data_petit.py
+++ b/antea/scripts/process_data_petit.py
@@ -40,6 +40,7 @@ def process_data_petit(input_file, output_file):
         df0 = pd.concat([df0, df_center], ignore_index=False, sort=False)
 
     df    = df0.reset_index()
+    df    = df.astype({'evt_number': int})
     store = pd.HDFStore(output_file, "w", complib=str("zlib"), complevel=4)
     store.put('data', df, format='table', data_columns=True)
     store.close()

--- a/antea/testdata/full_body_1evt_new_tof.h5
+++ b/antea/testdata/full_body_1evt_new_tof.h5
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48f964db4dc463264da99cbd087f7225f1438c764af601dbde4dd0bd6470f2ac
+size 47598112


### PR DESCRIPTION
This PR adapts one function and one script to use the new `tof` table format.
I had also to fix an unrelated error (caused by PyTable), which I suspect it depends on the machine you're running on. Anyway, the fix should work everywhere, since it's just an explicit cast.