### PR TITLE
Make sure we use a view of the sliced dataframe and not a copy

### DIFF
--- a/antea/mcsim/sensor_functions.py
+++ b/antea/mcsim/sensor_functions.py
@@ -11,11 +11,14 @@ def apply_charge_fluctuation(sns_df: pd.DataFrame, DataSiPM_idx: pd.DataFrame):
 
     pe_resolution = DataSiPM_idx.Sigma / DataSiPM_idx.adc_to_pes
     ## The next line avoids resetting the names in the original.
-    pe_resolution = pe_resolution.reset_index().rename(columns={'SensorID': 'sensor_id'})
-    fluct_sns     = sns_df.join(pe_resolution.set_index('sensor_id'), on='sensor_id')
+    pe_resolution = pe_resolution.reset_index().rename(
+        columns={'SensorID': 'sensor_id'})
+    fluct_sns     = sns_df.join(pe_resolution.set_index('sensor_id'),
+                                on='sensor_id')
     fluct_sns.rename(columns={0:'pe_res'}, inplace=True)
 
-    fluct_sns['charge'] += np.apply_along_axis(rand_normal, 0, fluct_sns.pe_res)
+    fluct_sns.loc[:, 'charge'] += np.apply_along_axis(rand_normal, 0,
+                                                      fluct_sns.pe_res)
 
     columns    = ['event_id', 'sensor_id', 'charge']
     return fluct_sns.loc[fluct_sns.charge > 0, columns]
@@ -25,7 +28,8 @@ def apply_sipm_pde(sns_df: pd.DataFrame, pde: float) -> pd.DataFrame:
     """
     Apply a photodetection efficiency on a dataframe with sensor response.
     """
-    sns_df['det_charge'] = sns_df.charge.apply(lambda x: np.count_nonzero(np.random.uniform(0, 1, x)<pde))
+    sns_df['det_charge'] = sns_df.charge.apply(
+        lambda x: np.count_nonzero(np.random.uniform(0, 1, x)<pde))
     sns_df = sns_df[sns_df.det_charge>0]
     sns_df = sns_df.drop(['charge'], axis=1).rename(columns={'det_charge': 'charge'})
 

--- a/antea/scripts/process_mc_petit.py
+++ b/antea/scripts/process_mc_petit.py
@@ -25,7 +25,7 @@ def process_mc_petit(input_file, output_file):
     df = mcio.load_mcsns_response(input_file)
 
     evt_groupby     = ['event_id']
-    df['tofpet_id'] = df['sensor_id'].apply(prf.tofpetid)
+    df.insert(len(df.columns), 'tofpet_id', df['sensor_id'].apply(prf.tofpetid))
 
     df_coinc  = prf.compute_coincidences(df, evt_groupby=evt_groupby)
     df_center = prf.select_evts_with_max_charge_at_center(df_coinc, evt_groupby=evt_groupby, variable='charge')


### PR DESCRIPTION
This change follows what is suggested by a warning of pandas itself, pointing to:
https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy.

Using `loc`, we make sure that the behaviour is that expected, namely, that a view of the column is modified, and not a copy.